### PR TITLE
The NumStopTimes attribute is not updated correctly when trips are deleted

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -89,25 +89,25 @@ func NewPolygon(outer [][2]float64, inners [][][2]float64) Polygon {
 
 // A ParseOptions object holds options for parsing a the feed
 type ParseOptions struct {
-	UseDefValueOnError    bool
-	DropErroneous         bool
-	DryRun                bool
-	CheckNullCoordinates  bool
-	EmptyStringRepl       string
-	ZipFix                bool
-	ShowWarnings          bool
-	DropShapes            bool
-	KeepAddFlds           bool
-	DateFilterStart       gtfs.Date
-	DateFilterEnd         gtfs.Date
-	PolygonFilter         []Polygon
-	UseStandardRouteTypes bool
-	MOTFilter             map[int16]bool
-	MOTFilterNeg          map[int16]bool
-	AssumeCleanCsv        bool
-	RemoveFillers         bool
+	UseDefValueOnError           bool
+	DropErroneous                bool
+	DryRun                       bool
+	CheckNullCoordinates         bool
+	EmptyStringRepl              string
+	ZipFix                       bool
+	ShowWarnings                 bool
+	DropShapes                   bool
+	KeepAddFlds                  bool
+	DateFilterStart              gtfs.Date
+	DateFilterEnd                gtfs.Date
+	PolygonFilter                []Polygon
+	UseStandardRouteTypes        bool
+	MOTFilter                    map[int16]bool
+	MOTFilterNeg                 map[int16]bool
+	AssumeCleanCsv               bool
+	RemoveFillers                bool
 	UseGoogleSupportedRouteTypes bool
-	DropSingleStopTrips bool
+	DropSingleStopTrips          bool
 }
 
 type ErrStats struct {
@@ -2050,13 +2050,13 @@ func polyContCheck(ax float64, ay float64, bx float64, by float64, cx float64, c
 	EPSILON := 0.00000001
 	if ay == by && ay == cy {
 		if !((bx <= ax && ax <= cx) ||
-		(cx <= ax && ax <= bx)) {
+			(cx <= ax && ax <= bx)) {
 			return 1
 		}
 		return 0
 	}
 	if math.Abs(ay-by) < EPSILON &&
-	math.Abs(ax-by) < EPSILON {
+		math.Abs(ax-by) < EPSILON {
 		return 0
 	}
 
@@ -2074,7 +2074,7 @@ func polyContCheck(ax float64, ay float64, bx float64, by float64, cx float64, c
 	}
 
 	d := (bx-ax)*(cy-ay) -
-	(by-ay)*(cx-ax)
+		(by-ay)*(cx-ax)
 
 	if d > 0 {
 		return -1
@@ -2156,6 +2156,8 @@ func (feed *Feed) DeleteFareAttribute(id string) {
 }
 
 func (feed *Feed) DeleteTrip(id string) {
+    feed.NumStopTimes -= len(feed.Trips[id].StopTimes)
+
 	delete(feed.Trips, id)
 
 	// delete additional fields from CSV


### PR DESCRIPTION
Hey @patrickbr 

I noticed that the attribute feed.NumStopTimes is not decreased when calling deleteTrip, so "phantom stop times" are still counted.

Sorry for the auto-formatted code.

Best,
Patrick