### PR TITLE
Check colour contrast

### DIFF
--- a/color_utils.go
+++ b/color_utils.go
@@ -1,0 +1,75 @@
+package gtfsparser
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+)
+
+// Converts a hex color (e.g., "AABBCC") to normalized RGB (0..1)
+func hexToRGB(hex string) (r, g, b float64, err error) {
+	if len(hex) != 6 {
+		return 0, 0, 0, fmt.Errorf("invalid hex color: %s", hex)
+	}
+	parse := func(s string) (float64, error) {
+		val, err := strconv.ParseInt(s, 16, 64)
+		if err != nil {
+			return 0, err
+		}
+		return float64(val) / 255.0, nil
+	}
+
+	r, err = parse(hex[0:2])
+	if err != nil {
+		return
+	}
+	g, err = parse(hex[2:4])
+	if err != nil {
+		return
+	}
+	b, err = parse(hex[4:6])
+	if err != nil {
+		return
+	}
+	return
+}
+
+// Computes relative luminance using WCAG formula
+func relativeLuminance(r, g, b float64) float64 {
+	convert := func(c float64) float64 {
+		if c <= 0.03928 {
+			return c / 12.92
+		}
+		return math.Pow((c+0.055)/1.055, 2.4)
+	}
+	return 0.2126*convert(r) + 0.7152*convert(g) + 0.0722*convert(b)
+}
+
+// Computes contrast ratio between two luminances
+func contrastRatio(l1, l2 float64) float64 {
+	light := math.Max(l1, l2)
+	dark := math.Min(l1, l2)
+	return (light + 0.05) / (dark + 0.05)
+}
+
+// Checks and prints WCAG contrast evaluation
+// See https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+// "The visual presentation of text and images of text has a contrast ratio of at least 4.5:1""
+
+func hasValidContrast(fgHex, bgHex string) bool {
+	fgR, fgG, fgB, err := hexToRGB(fgHex)
+	if err != nil {
+		log.Fatalf("Invalid foreground color: %v", err)
+	}
+	bgR, bgG, bgB, err := hexToRGB(bgHex)
+	if err != nil {
+		log.Fatalf("Invalid background color: %v", err)
+	}
+
+	fgLum := relativeLuminance(fgR, fgG, fgB)
+	bgLum := relativeLuminance(bgR, bgG, bgB)
+	ratio := contrastRatio(fgLum, bgLum)
+
+	return ratio >= 4.5
+}

--- a/color_utils_test.go
+++ b/color_utils_test.go
@@ -1,0 +1,137 @@
+package gtfsparser
+
+import (
+	"math"
+	"testing"
+)
+
+func TestHasValidContrast(t *testing.T) {
+	tests := []struct {
+		name     string
+		fg       string
+		bg       string
+		expected bool
+	}{
+		{
+			name:     "High contrast: black on white",
+			fg:       "000000",
+			bg:       "FFFFFF",
+			expected: true,
+		},
+		{
+			name:     "High contrast: white on black",
+			fg:       "FFFFFF",
+			bg:       "000000",
+			expected: true,
+		},
+		{
+			name:     "Low contrast: grey on slightly lighter grey",
+			fg:       "777777",
+			bg:       "AAAAAA",
+			expected: false,
+		},
+		{
+			name:     "Invalid contrast: blue on red",
+			fg:       "0000FF",
+			bg:       "FF0000",
+			expected: false,
+		},
+		{
+			name:     "Edge case: same color",
+			fg:       "123456",
+			bg:       "123456",
+			expected: false,
+		},
+		{
+			name:     "Pass: yellow on black",
+			fg:       "FFFF00",
+			bg:       "000000",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasValidContrast(tt.fg, tt.bg)
+			if result != tt.expected {
+				t.Errorf("hasValidContrast(%q, %q) = %v; want %v", tt.fg, tt.bg, result, tt.expected)
+			}
+		})
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	const epsilon = 1e-6
+	return math.Abs(a-b) < epsilon
+}
+
+func TestHexToRGB(t *testing.T) {
+	tests := []struct {
+		hex      string
+		expected [3]float64
+		wantErr  bool
+	}{
+		{"FFFFFF", [3]float64{1.0, 1.0, 1.0}, false},
+		{"000000", [3]float64{0.0, 0.0, 0.0}, false},
+		{"FF0000", [3]float64{1.0, 0.0, 0.0}, false},
+		{"00FF00", [3]float64{0.0, 1.0, 0.0}, false},
+		{"0000FF", [3]float64{0.0, 0.0, 1.0}, false},
+		{"123456", [3]float64{0x12 / 255.0, 0x34 / 255.0, 0x56 / 255.0}, false},
+		{"ZZZZZZ", [3]float64{}, true},
+		{"ABC", [3]float64{}, true},
+	}
+
+	for _, tt := range tests {
+		r, g, b, err := hexToRGB(tt.hex)
+		if tt.wantErr && err == nil {
+			t.Errorf("hexToRGB(%q) expected error, got none", tt.hex)
+		}
+		if !tt.wantErr {
+			if err != nil {
+				t.Errorf("hexToRGB(%q) unexpected error: %v", tt.hex, err)
+			} else if !(almostEqual(r, tt.expected[0]) && almostEqual(g, tt.expected[1]) && almostEqual(b, tt.expected[2])) {
+				t.Errorf("hexToRGB(%q) = (%f, %f, %f); want (%f, %f, %f)", tt.hex, r, g, b, tt.expected[0], tt.expected[1], tt.expected[2])
+			}
+		}
+	}
+}
+
+func TestRelativeLuminance(t *testing.T) {
+	tests := []struct {
+		r, g, b float64
+		want    float64
+	}{
+		{1.0, 1.0, 1.0, 1.0},      // white
+		{0.0, 0.0, 0.0, 0.0},      // black
+		{1.0, 0.0, 0.0, 0.2126},   // red
+		{0.0, 1.0, 0.0, 0.7152},   // green
+		{0.0, 0.0, 1.0, 0.0722},   // blue
+		{0.5, 0.5, 0.5, 0.214041}, // mid-gray approx
+	}
+
+	for _, tt := range tests {
+		got := relativeLuminance(tt.r, tt.g, tt.b)
+		if !almostEqual(got, tt.want) {
+			t.Errorf("relativeLuminance(%f, %f, %f) = %f; want %f", tt.r, tt.g, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestContrastRatio(t *testing.T) {
+	tests := []struct {
+		l1, l2 float64
+		want   float64
+	}{
+		{1.0, 0.0, 21.0}, // max contrast
+		{0.5, 0.5, 1.0},  // no contrast
+		{0.8, 0.2, (0.8 + 0.05) / (0.2 + 0.05)},
+		{0.7, 0.3, (0.7 + 0.05) / (0.3 + 0.05)},
+	}
+
+	for _, tt := range tests {
+		got := contrastRatio(tt.l1, tt.l2)
+		if !almostEqual(got, tt.want) {
+			t.Errorf("contrastRatio(%f, %f) = %f; want %f", tt.l1, tt.l2, got, tt.want)
+		}
+	}
+}

--- a/feed_test.go
+++ b/feed_test.go
@@ -7,7 +7,6 @@
 package gtfsparser
 
 import (
-	// "github.com/patrickbr/gtfsparser/gtfs"
 	"testing"
 )
 
@@ -60,6 +59,11 @@ func TestFeedParsing(t *testing.T) {
 
 	if len(shp.Points) != 7 {
 		t.Error(len(shp.Points))
+	}
+
+	// the one route with invalid color contrast should be removed
+	if len(feedFailA.Routes) != 16 {
+		t.Error(len(feedFailA.Routes))
 	}
 
 	feedCorB := NewFeed()

--- a/feed_test.go
+++ b/feed_test.go
@@ -61,11 +61,6 @@ func TestFeedParsing(t *testing.T) {
 		t.Error(len(shp.Points))
 	}
 
-	// the one route with invalid color contrast should be removed
-	if len(feedFailA.Routes) != 16 {
-		t.Error(len(feedFailA.Routes))
-	}
-
 	feedCorB := NewFeed()
 	feedCorB.SetParseOpts(ParseOptions{UseDefValueOnError: false, DropErroneous: false, DryRun: false})
 

--- a/mapping.go
+++ b/mapping.go
@@ -962,6 +962,10 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 	a.Continuous_pickup = int8(getRangeIntWithDefault(flds.continuousPickup, r, flds.FldName(flds.routeSortOrder), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
 	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
 
+	if !hasValidContrast(a.Text_color, a.Color) {
+		return nil, errors.New("Invalid color contrast between text_color and color!")
+	}
+
 	return a, nil
 }
 

--- a/mapping.go
+++ b/mapping.go
@@ -10,13 +10,14 @@ import (
 	hex "encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/patrickbr/gtfsparser/gtfs"
-	"github.com/valyala/fastjson/fastfloat"
 	"math"
 	mail "net/mail"
 	url "net/url"
 	"regexp"
 	"strings"
+
+	"github.com/patrickbr/gtfsparser/gtfs"
+	"github.com/valyala/fastjson/fastfloat"
 )
 
 var emptyTz, _ = gtfs.NewTimezone("")
@@ -928,11 +929,6 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 
 	a.Short_name = getString(flds.routeShortName, r, flds.FldName(flds.routeShortName), false, false, "")
 	a.Long_name = getString(flds.routeLongName, r, flds.FldName(flds.routeLongName), false, false, "")
-
-	if feed.opts.RemoveFillers {
-		a.Short_name = removeFillers(a.Short_name)
-		a.Long_name = removeFillers(a.Long_name)
-	}
 
 	if feed.opts.RemoveFillers {
 		a.Short_name = removeFillers(a.Short_name)

--- a/mapping.go
+++ b/mapping.go
@@ -963,7 +963,7 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
 
 	if !hasValidContrast(a.Text_color, a.Color) {
-		return nil, errors.New("Invalid color contrast between text_color and color!")
+		feed.warn(fmt.Errorf("Invalid color for route %s contrast between text_color #%s and route_color #%s!", a.Id, a.Text_color, a.Color))
 	}
 
 	return a, nil

--- a/mapping.go
+++ b/mapping.go
@@ -963,7 +963,7 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
 
 	if !hasValidContrast(a.Text_color, a.Color) {
-		feed.warn(fmt.Errorf("Invalid color for route %s contrast between text_color #%s and route_color #%s!", a.Id, a.Text_color, a.Color))
+		feed.warn(fmt.Errorf("WARNING: Insufficient contrast between text_color #%s and route_color #%s for route %s", a.Text_color, a.Color, a.Id))
 	}
 
 	return a, nil

--- a/mapping.go
+++ b/mapping.go
@@ -963,7 +963,7 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
 
 	if !hasValidContrast(a.Text_color, a.Color) {
-		feed.warn(fmt.Errorf("WARNING: Insufficient contrast between text_color #%s and route_color #%s for route %s", a.Text_color, a.Color, a.Id))
+		feed.warn(fmt.Errorf("Insufficient contrast between text_color #%s and route_color #%s for route %s", a.Text_color, a.Color, a.Id))
 	}
 
 	return a, nil

--- a/testfeeds/fail/a/routes.txt
+++ b/testfeeds/fail/a/routes.txt
@@ -15,3 +15,5 @@ AAMV,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM6,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM7,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM8,DTA,50,Airport - Amargosa Valley,,3,,,
+AAM9,DTA,50,Not enough color contrast,,3,,000000,222222
+AAM10,DTA,50,Not enough color contrast,,3,,222222,343434

--- a/testfeeds/fail/a/routes.txt
+++ b/testfeeds/fail/a/routes.txt
@@ -15,5 +15,3 @@ AAMV,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM6,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM7,DTA,50,Airport - Amargosa Valley,,3,,,
 AAM8,DTA,50,Airport - Amargosa Valley,,3,,,
-AAM9,DTA,50,Not enough color contrast,,3,,000000,222222
-AAM10,DTA,50,Not enough color contrast,,3,,222222,343434


### PR DESCRIPTION
Added a WCAG-based contrast checker for route colors in `routes.txt`. It verifies that `text_color` has sufficient contrast against `color` using the standard luminance formula. 

Also, in `mapping.go`, i removed a duplicate code block (see `feed.opts.RemoveFillers`)