### PR TITLE
Foreign Key Violation

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -10,14 +10,15 @@ import (
 	// "archive/zip"
 	"errors"
 	"fmt"
-	"github.com/klauspost/compress/zip"
-	"github.com/patrickbr/gtfsparser/gtfs"
 	"io"
 	"math"
 	"os"
 	opath "path"
 	"sort"
 	"unicode"
+
+	"github.com/klauspost/compress/zip"
+	"github.com/patrickbr/gtfsparser/gtfs"
 )
 
 // Holds the original column ordering
@@ -142,6 +143,7 @@ type Feed struct {
 	Pathways       map[string]*gtfs.Pathway
 	Transfers      map[gtfs.TransferKey]gtfs.TransferVal
 	FeedInfos      []*gtfs.FeedInfo
+	ZoneIds        map[string]bool
 
 	StopsAddFlds          map[string]map[string]string
 	AgenciesAddFlds       map[string]map[string]string
@@ -196,6 +198,7 @@ func NewFeed() *Feed {
 		Pathways:              make(map[string]*gtfs.Pathway),
 		Transfers:             make(map[gtfs.TransferKey]gtfs.TransferVal, 0),
 		FeedInfos:             make([]*gtfs.FeedInfo, 0),
+		ZoneIds:               make(map[string]bool, 0),
 		StopsAddFlds:          make(map[string]map[string]string),
 		StopTimesAddFlds:      make(map[string]map[string]map[int]string),
 		FrequenciesAddFlds:    make(map[string]map[string]map[*gtfs.Frequency]string),
@@ -568,6 +571,11 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 
 				feed.StopsAddFlds[reader.header[i]][stop.Id] = record[i]
 			}
+		}
+
+		// add zoneId if nonempty
+		if stop.Zone_id != "" {
+			feed.ZoneIds[stop.Zone_id] = true
 		}
 	}
 

--- a/feed.go
+++ b/feed.go
@@ -254,6 +254,11 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 	// with -De
 	filteredTrips := make(map[string]struct{}, 0)
 
+	// holds zones ids that are dropped because of geometric filtering.
+	// if these are referenced later, we quietly ignore the error like
+	// with -De
+	geofilteredZones := make(map[string]struct{}, 0)
+
 	e = feed.parseAgencies(path, prefix)
 	if e == nil {
 		e = feed.parseFeedInfos(path)
@@ -262,7 +267,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 		e = feed.parseLevels(path, prefix)
 	}
 	if e == nil {
-		e = feed.parseStops(path, prefix, geofilteredStops)
+		e = feed.parseStops(path, prefix, geofilteredStops, geofilteredZones)
 	}
 	if e == nil {
 		e = feed.reserveShapes(path, prefix)
@@ -302,7 +307,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 		e = feed.parseFareAttributes(path, prefix)
 	}
 	if e == nil {
-		e = feed.parseFareAttributeRules(path, prefix, filteredRoutes)
+		e = feed.parseFareAttributeRules(path, prefix, filteredRoutes, geofilteredZones)
 	}
 	if e == nil {
 		e = feed.parseFrequencies(path, prefix, filteredTrips)
@@ -485,7 +490,7 @@ func (feed *Feed) parseAgencies(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]struct{}) (err error) {
+func (feed *Feed) parseStops(path string, prefix string, geofilteredStops map[string]struct{}, geofilteredZones map[string]struct{}) (err error) {
 	file, e := feed.getFile(path, "stops.txt")
 
 	if e != nil {
@@ -524,6 +529,9 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 		addFlds = addiFields(reader.header, flds)
 	}
 
+	zoneSeen := make(map[string]int)
+	zoneKept := make(map[string]int)
+
 	parentStopIds := make(map[string]string, 0)
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		stop, parentId, e := createStop(record, flds, feed, prefix)
@@ -552,9 +560,18 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 			}
 		}
 
+		if stop.Zone_id != "" {
+			zoneSeen[stop.Zone_id]++
+		}
+
 		if !contains {
-			geofiltered[stop.Id] = struct{}{}
+			geofilteredStops[stop.Id] = struct{}{}
 			continue
+		}
+
+		if stop.Zone_id != "" {
+			zoneKept[stop.Zone_id]++
+			feed.ZoneIds[stop.Zone_id] = true
 		}
 
 		if len(parentId) > len(prefix) {
@@ -572,10 +589,11 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 				feed.StopsAddFlds[reader.header[i]][stop.Id] = record[i]
 			}
 		}
+	}
 
-		// add zoneId if nonempty
-		if stop.Zone_id != "" {
-			feed.ZoneIds[stop.Zone_id] = true
+	for zoneID, seen := range zoneSeen {
+		if seen > 0 && zoneKept[zoneID] == 0 {
+			geofilteredZones[zoneID] = struct{}{}
 		}
 	}
 
@@ -586,7 +604,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 		pstop, ok := feed.Stops[pid]
 		if !ok {
 			locErr := errors.New("(for stop id " + id + ") No station with id " + pid + " found, cannot use as parent station here.")
-			_, wasFiltered := geofiltered[pid]
+			_, wasFiltered := geofilteredStops[pid]
 
 			// note: if type >= 2, a parent Id is *required*
 			if wasFiltered && feed.Stops[id].Location_type < 2 {
@@ -1393,7 +1411,7 @@ func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRoutes map[string]struct{}) (err error) {
+func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRoutes map[string]struct{}, geofilteredZones map[string]struct{}) (err error) {
 	file, e := feed.getFile(path, "fare_rules.txt")
 
 	if e != nil {
@@ -1423,7 +1441,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-		fare, rule, e := createFareRule(record, flds, feed, prefix)
+		fare, rule, e := createFareRule(record, flds, feed, prefix, geofilteredZones)
 		if e != nil {
 			routeNotFoundErr, routeNotFound := e.(*RouteNotFoundErr)
 			wasFiltered := false
@@ -1432,9 +1450,11 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 			}
 
 			if wasFiltered {
+				// silently drop route-related rule
+				feed.ErrorStats.DroppedFareAttributeRules++
 				continue
 			} else if feed.opts.DropErroneous {
-				feed.ErrorStats.DroppedFareAttributeRules++
+				// do not count DroppedFareAttributeRules again, since we already did the couting in checkZoneId
 				feed.warn(e)
 				continue
 			} else {

--- a/feed.go
+++ b/feed.go
@@ -1443,17 +1443,22 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fare, rule, e := createFareRule(record, flds, feed, prefix, geofilteredZones)
 		if e != nil {
-			feed.ErrorStats.DroppedFareAttributeRules++
 			routeNotFoundErr, routeNotFound := e.(*RouteNotFoundErr)
 			wasFiltered := false
 			if routeNotFound {
 				_, wasFiltered = filteredRoutes[routeNotFoundErr.RouteId()]
 			}
 
+			zoneNotFoundError, zoneNotFound := e.(*ZoneNotFoundError)
+			if zoneNotFound {
+				_, wasFiltered = geofilteredZones[zoneNotFoundError.ZoneId()]
+			}
+
 			if wasFiltered {
 				// silently drop route-related rule
 				continue
 			} else if feed.opts.DropErroneous {
+				feed.ErrorStats.DroppedFareAttributeRules++
 				feed.warn(e)
 				continue
 			} else {

--- a/feed.go
+++ b/feed.go
@@ -1443,6 +1443,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fare, rule, e := createFareRule(record, flds, feed, prefix, geofilteredZones)
 		if e != nil {
+			feed.ErrorStats.DroppedFareAttributeRules++
 			routeNotFoundErr, routeNotFound := e.(*RouteNotFoundErr)
 			wasFiltered := false
 			if routeNotFound {
@@ -1451,10 +1452,8 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 
 			if wasFiltered {
 				// silently drop route-related rule
-				feed.ErrorStats.DroppedFareAttributeRules++
 				continue
 			} else if feed.opts.DropErroneous {
-				// do not count DroppedFareAttributeRules again, since we already did the couting in checkZoneId
 				feed.warn(e)
 				continue
 			} else {

--- a/mapping.go
+++ b/mapping.go
@@ -10,13 +10,14 @@ import (
 	hex "encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/patrickbr/gtfsparser/gtfs"
-	"github.com/valyala/fastjson/fastfloat"
 	"math"
 	mail "net/mail"
 	url "net/url"
 	"regexp"
 	"strings"
+
+	"github.com/patrickbr/gtfsparser/gtfs"
+	"github.com/valyala/fastjson/fastfloat"
 )
 
 var emptyTz, _ = gtfs.NewTimezone("")
@@ -1025,7 +1026,7 @@ func createServiceFromCalendarDates(r []string, flds CalendarDatesFields, feed *
 			return nil, errors.New("Date exception for service id " + getString(flds.serviceId, r, flds.FldName(flds.serviceId), true, true, "") + " defined 2 times for one date.")
 		}
 		if (filterDateEnd.IsEmpty() || !date.GetTime().After(filterDateEnd.GetTime())) &&
-		(filterDateStart.IsEmpty() || !date.GetTime().Before(filterDateStart.GetTime())) {
+			(filterDateStart.IsEmpty() || !date.GetTime().Before(filterDateStart.GetTime())) {
 			service.SetExceptionTypeOn(date, int8(t))
 		}
 	}
@@ -1563,6 +1564,16 @@ func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string) 
 	rule.Destination_id = prefix + getString(flds.destinationId, r, flds.FldName(flds.destinationId), false, false, "")
 	rule.Contains_id = prefix + getString(flds.containsId, r, flds.FldName(flds.containsId), false, false, "")
 
+	if _, ok := feed.ZoneIds[rule.Origin_id]; !ok {
+		feed.warn(fmt.Errorf("No zone_id '%s' (origin_id) defined in stops.txt", rule.Origin_id))
+	}
+	if _, ok := feed.ZoneIds[rule.Destination_id]; !ok {
+		feed.warn(fmt.Errorf("No zone_id '%s' (destination_id) defined in stops.txt", rule.Destination_id))
+	}
+	if _, ok := feed.ZoneIds[rule.Contains_id]; !ok {
+		feed.warn(fmt.Errorf("No zone_id '%s' (contains_id) defined in stops.txt", rule.Contains_id))
+	}
+
 	fareattr.Rules = append(fareattr.Rules, rule)
 
 	return fareattr, rule, nil
@@ -1719,7 +1730,7 @@ func createLevel(r []string, flds LevelFields, feed *Feed, idprefix string) (t *
 
 func getString(id int, r []string, fldName string, req bool, nonempty bool, emptyrepl string) string {
 	if id >= 0 {
-		if id < len(r) && len(r[id]) > 0{
+		if id < len(r) && len(r[id]) > 0 {
 			return r[id]
 		}
 		if nonempty {
@@ -2040,7 +2051,7 @@ func getTime(id int, r []string, fldName string) gtfs.Time {
 
 	return gtfs.Time{Hour: int8(hour), Minute: int8(minute), Second: int8(second)}
 
-	fail:
+fail:
 	panic(fmt.Errorf("Expected HH:MM:SS time for field '%s', found '%s' (%s)", fldName, errFldPrep(r[id]), e.Error()))
 }
 

--- a/mapping.go
+++ b/mapping.go
@@ -1613,7 +1613,6 @@ func (feed *Feed) checkZoneID(
 	// however, it could be that we havent seen it bcs we filtered it out
 	if _, ok := geofilteredZones[*zoneID]; ok {
 		// silently drop
-		feed.ErrorStats.DroppedFareAttributeRules++
 		return true, nil
 	}
 
@@ -1629,7 +1628,6 @@ func (feed *Feed) checkZoneID(
 	}
 
 	if feed.opts.DropErroneous {
-		feed.ErrorStats.DroppedFareAttributes++
 		feed.warn(locErr)
 		return true, nil
 	}

--- a/mapping.go
+++ b/mapping.go
@@ -674,6 +674,18 @@ func (e *TripNotFoundErr) TripId() string {
 	return e.prefix + e.tid
 }
 
+type ZoneNotFoundError struct {
+	zid string
+}
+
+func (z *ZoneNotFoundError) Error() string {
+	return "No zone with id " + z.zid + " found."
+}
+
+func (z *ZoneNotFoundError) ZoneId() string {
+	return z.zid
+}
+
 func createTranslation(r []string, flds TranslationFields, feed *Feed, prefix string) (attr *gtfs.Translation, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1564,29 +1576,19 @@ func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string, 
 	rule.Destination_id = prefix + getString(flds.destinationId, r, flds.FldName(flds.destinationId), false, false, "")
 	rule.Contains_id = prefix + getString(flds.containsId, r, flds.FldName(flds.containsId), false, false, "")
 
-	drop, err := feed.checkZoneID(&rule.Origin_id, "origin_id", geofilteredZones)
+	err = feed.checkZoneID(&rule.Origin_id, "origin_id")
 	if err != nil {
 		return nil, nil, err
 	}
-	if drop {
-		return fareattr, nil, nil
-	}
 
-	drop, err = feed.checkZoneID(&rule.Destination_id, "destination_id", geofilteredZones)
+	err = feed.checkZoneID(&rule.Destination_id, "destination_id")
 	if err != nil {
 		return nil, nil, err
 	}
-	if drop {
-		return fareattr, nil, nil
-	}
 
-	drop, err = feed.checkZoneID(&rule.Contains_id, "contains_id", geofilteredZones)
+	err = feed.checkZoneID(&rule.Contains_id, "contains_id")
 	if err != nil {
 		return nil, nil, err
-	}
-	if drop {
-		return fareattr, nil, nil
-
 	}
 
 	fareattr.Rules = append(fareattr.Rules, rule)
@@ -1594,45 +1596,24 @@ func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string, 
 	return fareattr, rule, nil
 }
 
+// checkZoneID only validates existence; filtering and policy decisions
+// are handled by the caller.
 func (feed *Feed) checkZoneID(
 	zoneID *string,
 	fieldName string,
-	geofilteredZones map[string]struct{},
-) (drop bool, err error) {
+) error {
 
 	if *zoneID == "" {
-		return false, nil
+		return nil
 	}
 
-	// if we have seen this zone id, all good
 	if _, ok := feed.ZoneIds[*zoneID]; ok {
-		return false, nil
+		return nil
 	}
 
-	// at this point, we have not seen the zone id
-	// however, it could be that we havent seen it bcs we filtered it out
-	if _, ok := geofilteredZones[*zoneID]; ok {
-		// silently drop
-		return true, nil
+	return &ZoneNotFoundError{
+		zid: *zoneID,
 	}
-
-	locErr := fmt.Errorf(
-		"No zone_id '%s' (%s) defined in stops.txt",
-		*zoneID, fieldName,
-	)
-
-	if feed.opts.UseDefValueOnError {
-		*zoneID = ""
-		feed.warn(locErr)
-		return false, nil
-	}
-
-	if feed.opts.DropErroneous {
-		feed.warn(locErr)
-		return true, nil
-	}
-
-	return false, locErr
 }
 
 func createTransfer(r []string, flds TransferFields, feed *Feed, prefix string) (tk gtfs.TransferKey, tv gtfs.TransferVal, err error) {

--- a/mapping.go
+++ b/mapping.go
@@ -1528,7 +1528,7 @@ func createFareAttribute(r []string, flds FareAttributeFields, feed *Feed, prefi
 	return a, nil
 }
 
-func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string) (fare *gtfs.FareAttribute, rl *gtfs.FareAttributeRule, err error) {
+func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string, geofilteredZones map[string]struct{}) (fare *gtfs.FareAttribute, rl *gtfs.FareAttributeRule, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = r.(error)
@@ -1540,7 +1540,7 @@ func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string) 
 
 	fareid = prefix + getString(flds.fareId, r, flds.FldName(flds.fareId), true, true, "")
 
-	// first, check if the service already exists
+	// first, check if the fare already exists
 	if val, ok := feed.FareAttributes[fareid]; ok {
 		fareattr = val
 	} else {
@@ -1564,19 +1564,77 @@ func createFareRule(r []string, flds FareRuleFields, feed *Feed, prefix string) 
 	rule.Destination_id = prefix + getString(flds.destinationId, r, flds.FldName(flds.destinationId), false, false, "")
 	rule.Contains_id = prefix + getString(flds.containsId, r, flds.FldName(flds.containsId), false, false, "")
 
-	if _, ok := feed.ZoneIds[rule.Origin_id]; !ok {
-		feed.warn(fmt.Errorf("No zone_id '%s' (origin_id) defined in stops.txt", rule.Origin_id))
+	drop, err := feed.checkZoneID(&rule.Origin_id, "origin_id", geofilteredZones)
+	if err != nil {
+		return nil, nil, err
 	}
-	if _, ok := feed.ZoneIds[rule.Destination_id]; !ok {
-		feed.warn(fmt.Errorf("No zone_id '%s' (destination_id) defined in stops.txt", rule.Destination_id))
+	if drop {
+		return fareattr, nil, nil
 	}
-	if _, ok := feed.ZoneIds[rule.Contains_id]; !ok {
-		feed.warn(fmt.Errorf("No zone_id '%s' (contains_id) defined in stops.txt", rule.Contains_id))
+
+	drop, err = feed.checkZoneID(&rule.Destination_id, "destination_id", geofilteredZones)
+	if err != nil {
+		return nil, nil, err
+	}
+	if drop {
+		return fareattr, nil, nil
+	}
+
+	drop, err = feed.checkZoneID(&rule.Contains_id, "contains_id", geofilteredZones)
+	if err != nil {
+		return nil, nil, err
+	}
+	if drop {
+		return fareattr, nil, nil
+
 	}
 
 	fareattr.Rules = append(fareattr.Rules, rule)
 
 	return fareattr, rule, nil
+}
+
+func (feed *Feed) checkZoneID(
+	zoneID *string,
+	fieldName string,
+	geofilteredZones map[string]struct{},
+) (drop bool, err error) {
+
+	if *zoneID == "" {
+		return false, nil
+	}
+
+	// if we have seen this zone id, all good
+	if _, ok := feed.ZoneIds[*zoneID]; ok {
+		return false, nil
+	}
+
+	// at this point, we have not seen the zone id
+	// however, it could be that we havent seen it bcs we filtered it out
+	if _, ok := geofilteredZones[*zoneID]; ok {
+		// silently drop
+		feed.ErrorStats.DroppedFareAttributeRules++
+		return true, nil
+	}
+
+	locErr := fmt.Errorf(
+		"No zone_id '%s' (%s) defined in stops.txt",
+		*zoneID, fieldName,
+	)
+
+	if feed.opts.UseDefValueOnError {
+		*zoneID = ""
+		feed.warn(locErr)
+		return false, nil
+	}
+
+	if feed.opts.DropErroneous {
+		feed.ErrorStats.DroppedFareAttributes++
+		feed.warn(locErr)
+		return true, nil
+	}
+
+	return false, locErr
 }
 
 func createTransfer(r []string, flds TransferFields, feed *Feed, prefix string) (tk gtfs.TransferKey, tv gtfs.TransferVal, err error) {


### PR DESCRIPTION
Although `zone_id` as foreign key is optional, it should still be a valid foreign key.
In `fare_rules.txt`: `origin_id`, `destination_id` and `contains_id` should all reference to a valid (i.e. existing) `zone_id` [GTFS Reference](https://gtfs.org/documentation/schedule/reference/#fare_rulestxt).

This PR prints a warning if a non-existing `zone_id` is referenced by a fare_rule.

```bash
WARNING: No zone_id '5#' (origin_id) defined in stops.txt
WARNING: No zone_id '5#' (destination_id) defined in stops.txt
```
I noticed this "bug" because the gtfs validator actually returns an ERROR for a violation like this.

childFilename | childFieldName | parentFilename | parentFieldName | fieldValue |  csvRowNumber
-- | -- | -- | -- | -- | --
"fare_rules.txt" | "origin_id" | "stops.txt" | "zone_id" | "5#" | 2
"fare_rules.txt" | "destination_id" | "stops.txt" | "zone_id" | "5#" | 3

Please let me know if you want some changes.