### PR TITLE
Allow Quoted Header Fields

### DIFF
--- a/csvparser.go
+++ b/csvparser.go
@@ -153,6 +153,8 @@ func (p *CsvParser) parseHeader() {
 	copy(p.header, rec)
 
 	for i, header := range rec {
+		header = strings.Trim(header, `"`)
+		p.header[i] = header
 		p.ret[header] = ""
 		p.headeridx[header] = i
 	}


### PR DESCRIPTION
While reading the GTFS dataset from MVV (see https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/opendata/index.html), i noticed that the current csv parser cannot read the header correctly, bcs they quoted the header names:

```bash
>>> head GTFS/stops.txt 
"stop_id","stop_code","stop_name","stop_lat","stop_lon","stop_url","location_type","parent_station","platform_code"
"at:45:50002","","Salzburg Hbf","47.8118785","13.0467988","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","1","",""
"at:45:50002:0:10","","Salzburg Hbf Gleis 7","47.8125059","13.0458106","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 7"
"at:45:50002:0:11","","Salzburg Hbf Gleis 8","47.8124878","13.0459274","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 8"
"at:45:50002:0:12","","Salzburg Hbf Gleis 9","47.8124516","13.0460352","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 9"
"at:45:50002:0:7","","Salzburg Hbf Gleis 4","47.8125964","13.0454513","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 4"
"at:45:50002:0:8","","Salzburg Hbf Gleis 5","47.8125542","13.0455771","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 5"
"at:45:50002:0:9","","Salzburg Hbf Gleis 6","47.8125421","13.0457028","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:50002","0","at:45:50002","Gleis 6"
"at:45:51023","","Salzburg, Mülln-Altstadt","47.8084096","13.0343212","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:51023","1","",""
"at:45:51023:1","","Salzburg, Mülln-Altstadt","47.8084156","13.0343212","https://efa.mvv-muenchen.de/index.html?name_origin=at:45:51023","0","at:45:51023",""
```

This PR fixes this